### PR TITLE
Issue with shapes in the linear class

### DIFF
--- a/resnet-simclr.py
+++ b/resnet-simclr.py
@@ -248,7 +248,8 @@ class LinearNet(nn.Module):
 
     def __init__(self):
         super(LinearNet, self).__init__()
-        self.fc1 = torch.nn.Linear(50, 5)
+        # self.fc1 = torch.nn.Linear(50, 5) 
+        self.fc1 = torch.nn.Linear(100, 25)
 
     def forward(self, x):
         x = self.fc1(x)


### PR DESCRIPTION
Hello, thank you for a nice implementation of the paper SimCLR. 

The notebook provided cannot run because of the shape issue in the linear class, from my experimentation we are getting a 125*100 out of our present but our linear layer in the linear class is expecting a 50, 5 which doesn't much and consequently, the model can't run. 

I'm suggesting to revise the entire model weight as my current modification works for a linear layer of 100, 25 which is not very consistent with our number of classes. 